### PR TITLE
replace install.sh and update.sh with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+
+install:
+	 @echo "==> fetchfetch installer"
+	 @echo "==> Made by gentoo-btw"
+	 @echo " "
+	 @echo "==> Installing fetchfetch.."
+	 @test -f /usr/bin/go && echo "==> Found go executable at /usr/bin/go."
+	 @test -f /usr/bin/go || echo "==> Go not found. please install go." || exit 1
+	 @echo "==> Running go to install fetchfetch.."
+	 @go install github.com/NikonP/fetchfetch@latest
+	 @echo "==> Installed fetchfetch."
+	 @echo "==> Make sure ~/go/bin is in your PATH"
+	 @echo " "
+	 @echo "==> Also. stop trying to make fetch happen (if your gonna make it happen)"
+	 @echo "==> We are tired of new fetch tools over and over again. so please don't you dare publish your fetch tool into reddit (e.g r/linux)"
+
+update:
+	 @echo "==> fetchfetch installer"
+	 @echo "==> Made by gentoo-btw"
+	 @echo " "
+	 @echo "==> Updating fetchfetch"
+	 @echo "==> Removing current fetchfetch executable. assuming path ~/go/bin/"
+	 @rm ~/go/bin/fetchfetch
+	 @echo "==> Installing fetchfetch (again)"
+	 @go install github.com/NikonP/fetchfetch@latest
+	 @echo "==> Updated fetchfetch"
+	 @echo "==> Make sure ~/go/bin is in your PATH."
+	 @echo " "
+	 @echo "==> Also. stop trying to make fetch happen (if your gonna make it happen)"
+	 @echo "==> We are tired of new fetch tools over and over again. so please don't you dare publish your fetch tool into reddit (e.g r/linux)"
+
+uninstall:
+	 @echo "==> fetchfetch installer"
+	 @echo "==> Made by gentoo-btw"
+	 @echo " "
+	 @echo "==> Removing fetchfetch. assuming to remove ~/go/bin/fetchfetch"
+	 @rm ~/go/bin/fetchfetch
+	 @echo "==> Thanks for using fetchfetch"
+	 @echo " "
+	 @echo "==> Also. stop trying to make fetch happen (if your gonna make it happen)"
+	 @echo "==> We are tired of new fetch tools over and over again. so please don't you dare publish your fetch tool into reddit (e.g r/linux)"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
 </div>
 </div>
 
+
+## 1 - Requirements
+
+`make` - for the installer
+
+`go` - for installing fetchfetch/executing fetchfetch
+
 ## 1 - Install
 
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 `go` - for installing fetchfetch/executing fetchfetch
 
-## 1 - Install
+## 2 - Install
 
 ```
 $ make install
@@ -29,13 +29,13 @@ $ make install
 
 or grab binary from [releases](https://github.com/NikonP/fetchfetch/releases)
 
-## 2 - Update
+## 3 - Update
 
 ```
 $ make update
 ```
 
-## 3 - Uninstall
+## 4 - Uninstall
 
 ```
 $ make uninstall

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## 1 - Install
 
 ```
-go install github.com/NikonP/fetchfetch@latest
+$ make install
 ```
 
 or grab binary from [releases](https://github.com/NikonP/fetchfetch/releases)
@@ -25,6 +25,11 @@ or grab binary from [releases](https://github.com/NikonP/fetchfetch/releases)
 ## 2 - Update
 
 ```
-rm ~/go/bin/fetchfetch
-go install github.com/NikonP/fetchfetch@latest
+$ make update
+```
+
+## 3 - Uninstall
+
+```
+$ make uninstall
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-go install github.com/NikonP/fetchfetch@latest

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-rm ~/go/bin/fetchfetch
-go install github.com/NikonP/fetchfetch@latest


### PR DESCRIPTION
preview when you run `make install`:
```
==> fetchfetch installer
==> Made by gentoo-btw
 
==> Installing fetchfetch..
==> Found go executable at /usr/bin/go.
==> Running go to install fetchfetch..
==> Installed fetchfetch.
==> Make sure ~/go/bin is in your PATH
 
==> Also. stop trying to make fetch happen (if your gonna make it happen)
==> We are tired of new fetch tools over and over again. so please don't you dare publish your fetch tool into reddit (e.g r/linux)
```

the "stop trying to make fetch happen" part. shows at all make commands (e.g `make install`, `make update`, `make uninstall`)

fetchfetch could've gained more popularity if you just published it into r/linux or r/unixp**n
or maybe i'll make a crosspost